### PR TITLE
Enable using different environments

### DIFF
--- a/.github/workflows/setup-and-run-fit.yml
+++ b/.github/workflows/setup-and-run-fit.yml
@@ -3,6 +3,8 @@ run-name: ${{ github.actor }} Run SIT tests with private endpoints
 on: 
   workflow_dispatch:
     inputs:
+      environment:
+        type: environment
       sdk:
         description: SDK Performer to use
         type: choice
@@ -28,7 +30,7 @@ jobs:
     name: Build
     runs-on: [self-hosted, aws]
     environment:
-      name: env
+      name: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Maven Central Repository
@@ -140,7 +142,7 @@ jobs:
           echo "`jq --arg e "${{ vars.CBDINO_PATH }}" '.situational.cbdino.cbDinoClusterAppPath=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.PGHOST }}" '.situational.database.jdbc=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.PGUSERNAME }}" '.situational.database.username=$e' FITConfiguration.json`" > FITConfiguration.json
-          echo "`jq --arg e "${{ vars.PGPASSWORD }}" '.situational.database.password=$e' FITConfiguration.json`" > FITConfiguration.json
+          echo "`jq --arg e "${{ secrets.PGPASSWORD }}" '.situational.database.password=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --argjson e "${{ github.event.inputs.private-endpoints }}" '.situational.cbdino.enablePrivateEndpoint=$e' FITConfiguration.json`" > FITConfiguration.json
           cat FITConfiguration.json
       - name: build driver docker image

--- a/.github/workflows/setup-and-run-fit.yml
+++ b/.github/workflows/setup-and-run-fit.yml
@@ -25,6 +25,12 @@ on:
         options:
         - "true"
         - "false"
+      server-version:
+        description: The server version to use on Capella (defaults only currrently, no specific images)
+        type: choice
+        options:
+        - "7.2"
+        - "7.6"
 jobs:
   build:
     name: Build
@@ -32,6 +38,8 @@ jobs:
     environment:
       name: ${{ github.event.inputs.environment }}
     steps:
+      - name: Run params
+        run: echo "${{ toJSON(github.event.inputs) }}"
       - uses: actions/checkout@v3
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
@@ -136,13 +144,13 @@ jobs:
         run: |
           cd transactions-fit-performer/test-driver
           echo "`jq --arg e "${{ vars.EXCLUDETESTS }}" '.excludeTests=[$e]' FITConfiguration.example.json`" > FITConfiguration.json
-          echo "`jq --arg e "${{ vars.SERVER_VERSION }}" '.situational.cbdino.version=$e' FITConfiguration.json`" > FITConfiguration.json
+          echo "`jq --arg e "${{ github.event.inputs.server-version }}" '.situational.cbdino.version=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.DEPLOYER }}" '.situational.cbdino.deployer=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.REGION }}" '.situational.cbdino.region=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.CBDINO_PATH }}" '.situational.cbdino.cbDinoClusterAppPath=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.PGHOST }}" '.situational.database.jdbc=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --arg e "${{ vars.PGUSERNAME }}" '.situational.database.username=$e' FITConfiguration.json`" > FITConfiguration.json
-          echo "`jq --arg e "${{ secrets.PGPASSWORD }}" '.situational.database.password=$e' FITConfiguration.json`" > FITConfiguration.json
+          echo "`jq --arg e "${{ secrets.PG_PASSWORD }}" '.situational.database.password=$e' FITConfiguration.json`" > FITConfiguration.json
           echo "`jq --argjson e "${{ github.event.inputs.private-endpoints }}" '.situational.cbdino.enablePrivateEndpoint=$e' FITConfiguration.json`" > FITConfiguration.json
           cat FITConfiguration.json
       - name: build driver docker image


### PR DESCRIPTION
Will allow us to add prod/stage/dev specific environments that have the right variables/passwords/etc. Have added 'prod', and the default 'env' is using a sbx currently. Since sandboxes will changes, I'll need to add some more options to enter custom env variables for those runs. I want to eliminate how I'm currently doing it - manually changing the env variables in the settings page - will do a follow up patch to address sbx runs.